### PR TITLE
py3 compatibility

### DIFF
--- a/beyonic/__init__.py
+++ b/beyonic/__init__.py
@@ -20,4 +20,4 @@ from beyonic.apis.transaction import Transaction
 from beyonic.apis.network import Network
 from beyonic.apis.currency import Currency
 
-__version__ = "0.1.14x"
+__version__ = "0.1.15"

--- a/beyonic/__init__.py
+++ b/beyonic/__init__.py
@@ -20,4 +20,4 @@ from beyonic.apis.transaction import Transaction
 from beyonic.apis.network import Network
 from beyonic.apis.currency import Currency
 
-__version__ = "0.1.14"
+__version__ = "0.1.14x"

--- a/beyonic/api_client.py
+++ b/beyonic/api_client.py
@@ -32,7 +32,7 @@ class BaseClient(object):
         if params and params.get('metadata', None):
             metadata = params.get('metadata')
             transformed_metadata = {}
-            for key, value in metadata.iteritems():
+            for key, value in metadata.items():
                 transformed_metadata['metadata.{}'.format(key)] = value
             params.pop('metadata')
             params.update(transformed_metadata)

--- a/beyonic/api_client.py
+++ b/beyonic/api_client.py
@@ -70,14 +70,14 @@ class RequestsClient(BaseClient):
                                               data=self.transform_params_metadata(params),
                                               timeout=80,
                                               **kwargs)
-            except TypeError, e:
+            except TypeError as e:
                 raise TypeError(
                     'Please upgrade your request library. The '
                     'underlying error was: %s' % (e,))
 
             content = result.content
             status_code = result.status_code
-        except Exception, e:
+        except Exception as e:
             # Would catch just requests.exceptions.RequestException, but can
             # also raise ValueError, RuntimeError, etc.
             self._handle_request_error(e)
@@ -110,7 +110,7 @@ class UrlFetchClient(BaseClient):
                 deadline=55,
                 payload=self.transform_params_metadata(params)
             )
-        except urlfetch.Error, e:
+        except urlfetch.Error as e:
             self._handle_request_error(e, url)
 
         return result.content, result.status_code


### PR DESCRIPTION
Since Python 2.7 is soon to be deprecated (Jan 2020), I have switched our dependent project (Asaak) to Python 3 and noticed that this package does not work under Python 3.

However, it can be made Py3-compatible with just a few lines (note that these lines do break compat with Python 2.6, which should be acceptable at this point)

CC @KayLuke 